### PR TITLE
Update System.Text.Json package version reference

### DIFF
--- a/src/dRofusClient/dRofusClient.csproj
+++ b/src/dRofusClient/dRofusClient.csproj
@@ -21,7 +21,7 @@
     <AssemblyName>$(PackageId).$(Version)</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="*" />
+    <PackageReference Include="System.Text.Json" Version="8.*" />
     <PackageReference Include="PolySharp" Version="*">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Changed the `System.Text.Json` package reference from a wildcard version (`*`) to a specific version range (`8.*`) to ensure compatibility with version 8 and above.