### PR TITLE
Use ConfigureAwait(false) across async library calls

### DIFF
--- a/src/dRofusClient.Windows/AttributeConfigurations/dRofusAttributeConfigurationExtensions.cs
+++ b/src/dRofusClient.Windows/AttributeConfigurations/dRofusAttributeConfigurationExtensions.cs
@@ -20,7 +20,7 @@ public static class dRofusAttributeConfigurationExtensions
         var options = Query.List()
                     .Filter(Filter.Eq("id", attributeConfigurationId));
 
-        var attributeConfigurations = await client.GetAttributeConfigurationsAsync(options);
+        var attributeConfigurations = await client.GetAttributeConfigurationsAsync(options).ConfigureAwait(false);
 
         if (attributeConfigurations.FirstOrDefault() is not { } attributeConfiguration)
             throw new InvalidOperationException($"Failed to get attribute configurations for id {attributeConfigurationId}");

--- a/src/dRofusClient.Windows/DialogPromptHandler.cs
+++ b/src/dRofusClient.Windows/DialogPromptHandler.cs
@@ -57,7 +57,7 @@ public class DialogPromptHandler(IdRofusClientFactory clientFactory, ModernLogin
 
         _loginWindow.Show();
 
-        var result = await tcs.Task.ConfigureAwait(true);
+        var result = await tcs.Task.ConfigureAwait(false);
 
         if (result == null)
         {

--- a/src/dRofusClient.Windows/UI/LoginViewModel.cs
+++ b/src/dRofusClient.Windows/UI/LoginViewModel.cs
@@ -121,7 +121,7 @@ public class LoginViewModel : ViewModelBase
 
         if (UseModernSignIn)
         {
-            await ExecuteModernLogin(cancellationToken);
+            await ExecuteModernLogin(cancellationToken).ConfigureAwait(false);
             return;
         }
 
@@ -129,7 +129,7 @@ public class LoginViewModel : ViewModelBase
 
         try
         {
-            await client.Login(args, cancellationToken);
+            await client.Login(args, cancellationToken).ConfigureAwait(false);
 
             if (RememberMe)
             {
@@ -160,7 +160,7 @@ public class LoginViewModel : ViewModelBase
 
         var modernPromptHandler = new ModernPromptHandler(_modernLoginOptions, _logger);
 
-        var result = await modernPromptHandler.HandleOidcAuthenticationAsync(ModernServer!, Database!, ProjectId!, cancellationToken);
+        var result = await modernPromptHandler.HandleOidcAuthenticationAsync(ModernServer!, Database!, ProjectId!, cancellationToken).ConfigureAwait(false);
         var args = ModernConnectionArgs.Create(ModernServer!, Database!, ProjectId!, result);
         _onLogin?.Invoke(args);
     }

--- a/src/dRofusClient/AttributeConfigurations/dRofusAttributeConfigurationExtensions.cs
+++ b/src/dRofusClient/AttributeConfigurations/dRofusAttributeConfigurationExtensions.cs
@@ -30,7 +30,7 @@ public static class dRofusAttributeConfigurationExtensions
     {
         var options = Query.List()
             .Filter(Filter.Eq("id", attributeConfigurationId));
-        var items = await client.GetListAsync<AttributeConfiguration>(dRofusType.AttributeConfigurations.ToRequest(), options, cancellationToken);
+        var items = await client.GetListAsync<AttributeConfiguration>(dRofusType.AttributeConfigurations.ToRequest(), options, cancellationToken).ConfigureAwait(false);
         return items.FirstOrDefault();
     }
 }

--- a/src/dRofusClient/Extensions/HttpContentExtensions.cs
+++ b/src/dRofusClient/Extensions/HttpContentExtensions.cs
@@ -7,8 +7,8 @@ internal static class HttpContentExtensions
     internal static async Task<T?> ReadFromJsonAsync<T>(this HttpContent content, CancellationToken cancellationToken)
     {
         var stream = new MemoryStream();
-        await content.CopyToAsync(stream);
+        await content.CopyToAsync(stream).ConfigureAwait(false);
         stream.Position = 0;
-        return await Json.DeserializeAsync<T>(stream, cancellationToken);
+        return await Json.DeserializeAsync<T>(stream, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/dRofusClient/Helpers/Json.cs
+++ b/src/dRofusClient/Helpers/Json.cs
@@ -14,7 +14,7 @@ public static class Json
     public static string Serialize(object obj) => JsonSerializer.Serialize(obj, Options);
 
     public static async Task<T?> DeserializeAsync<T>(Stream json, CancellationToken cancellationToken) 
-        => await JsonSerializer.DeserializeAsync<T>(json, Options, cancellationToken);
+        => await JsonSerializer.DeserializeAsync<T>(json, Options, cancellationToken).ConfigureAwait(false);
 }
 
 // Custom naming policy for snake_case

--- a/src/dRofusClient/ItemGroups/dRofusClientItemGroupExtensions.cs
+++ b/src/dRofusClient/ItemGroups/dRofusClientItemGroupExtensions.cs
@@ -67,7 +67,7 @@ public static class dRofusClientItemGroupExtensions
         var patchOptions = itemGroup.ToPatchRequest();
         ItemGroup? result = null;
         if (patchOptions.Body is not null && patchOptions.Body.Equals("{}") == false)
-            result = await client.PatchAsync<ItemGroup>(dRofusType.ItemGroups.CombineToRequest(itemGroup.Id), patchOptions, cancellationToken);
+            result = await client.PatchAsync<ItemGroup>(dRofusType.ItemGroups.CombineToRequest(itemGroup.Id), patchOptions, cancellationToken).ConfigureAwait(false);
         result ??= itemGroup with { Id = itemGroup.Id };
         return result;
     }

--- a/src/dRofusClient/Items/dRofusClientItemExtensions.cs
+++ b/src/dRofusClient/Items/dRofusClientItemExtensions.cs
@@ -43,7 +43,7 @@ public static class dRofusClientItemExtensions
     /// <returns>The <see cref="Item"/> object with the specified ID.</returns>
     public static async Task<Item> GetItemAsync(this IdRofusClient client, int id, ItemQuery? query = default, CancellationToken cancellationToken = default)
     {
-        var item = await client.GetAsync<Item>(dRofusType.Items.CombineToRequest(id), query, cancellationToken);
+        var item = await client.GetAsync<Item>(dRofusType.Items.CombineToRequest(id), query, cancellationToken).ConfigureAwait(false);
         return item;
     }
 
@@ -61,7 +61,7 @@ public static class dRofusClientItemExtensions
         var patchOptions = item.ToPatchRequest();
         Item? itemResult = null;
         if (patchOptions.Body is not null && patchOptions.Body.Equals("{}") == false)
-            itemResult = await client.PatchAsync<Item>(dRofusType.Items.CombineToRequest(item.Id), patchOptions, cancellationToken);
+            itemResult = await client.PatchAsync<Item>(dRofusType.Items.CombineToRequest(item.Id), patchOptions, cancellationToken).ConfigureAwait(false);
         itemResult ??= item with { Id = item.Id, AdditionalProperties = item.AdditionalProperties };
         return itemResult;
     }
@@ -127,9 +127,9 @@ public static class dRofusClientItemExtensions
             form.Add(new StringContent(description), "description");
 
         var request = new HttpRequestMessage(HttpMethod.Post, url) { Content = form };
-        var response = await client.HttpClient.SendAsync(request, cancellationToken);
+        var response = await client.HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<Files.FileUploadResponse>(cancellationToken) ?? new Files.FileUploadResponse();
+        return await response.Content.ReadFromJsonAsync<Files.FileUploadResponse>(cancellationToken).ConfigureAwait(false) ?? new Files.FileUploadResponse();
     }
 
     /// <summary>
@@ -140,7 +140,7 @@ public static class dRofusClientItemExtensions
         var (db, pr) = client.GetDatabaseAndProjectId();
         var url = $"/api/{db}/{pr}/" + dRofusType.Items.CombineToRequest(itemId, "files", fileId.ToString());
         var request = new HttpRequestMessage(HttpMethod.Post, url);
-        var response = await client.HttpClient.SendAsync(request, cancellationToken);
+        var response = await client.HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
     }
 
@@ -152,7 +152,7 @@ public static class dRofusClientItemExtensions
         var (db, pr) = client.GetDatabaseAndProjectId();
         var url = $"/api/{db}/{pr}/" + dRofusType.Items.CombineToRequest(itemId, "files", fileId.ToString());
         var request = new HttpRequestMessage(HttpMethod.Delete, url);
-        var response = await client.HttpClient.SendAsync(request, cancellationToken);
+        var response = await client.HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
     }
 

--- a/src/dRofusClient/ModernPromptHandler.cs
+++ b/src/dRofusClient/ModernPromptHandler.cs
@@ -83,7 +83,7 @@ public class ModernPromptHandler(ModernLoginOptions modernLoginOptions, ILogger?
         var baseUrl = client.GetBaseUrl();
         var server = dRofusServer.FromBaseUrl(baseUrl!);
 
-        var result = await HandleOidcAuthenticationAsync(server, db, pr, cancellationToken);
+        var result = await HandleOidcAuthenticationAsync(server, db, pr, cancellationToken).ConfigureAwait(false);
         client.UpdateAuthentication(result);
     }
 
@@ -93,7 +93,7 @@ public class ModernPromptHandler(ModernLoginOptions modernLoginOptions, ILogger?
         var authority = server.Authority;
         var browser = new SystemBrowser(new Uri(modernLoginOptions.RedirectUri).Port);
 
-        var discoveryDocument = await GetDiscoveryDocument(new HttpClient(), server);
+        var discoveryDocument = await GetDiscoveryDocument(new HttpClient(), server).ConfigureAwait(false);
 
         var options = new OidcClientOptions
         {
@@ -112,15 +112,15 @@ public class ModernPromptHandler(ModernLoginOptions modernLoginOptions, ILogger?
         if (!string.IsNullOrEmpty(db)) parameters.Add("db", db!);
         if (!string.IsNullOrEmpty(pr)) parameters.Add("pr", pr!);
 
-        var loginState = await oidcClient.PrepareLoginAsync(parameters, cancellationToken);
+        var loginState = await oidcClient.PrepareLoginAsync(parameters, cancellationToken).ConfigureAwait(false);
 
         // Use the browser instance directly, not loginState.Browser
         var browserResult = await browser.InvokeAsync(
             new BrowserOptions(loginState.StartUrl, options.RedirectUri),
             cancellationToken
-        );
+        ).ConfigureAwait(false);
 
-        var result = await oidcClient.ProcessResponseAsync(browserResult.Response, loginState, parameters, cancellationToken);
+        var result = await oidcClient.ProcessResponseAsync(browserResult.Response, loginState, parameters, cancellationToken).ConfigureAwait(false);
 
         if (result.IsError)
             throw new dRofusClientModernLoginException(result.Error)
@@ -131,7 +131,7 @@ public class ModernPromptHandler(ModernLoginOptions modernLoginOptions, ILogger?
 
     public async Task<ModernLoginResult> HandleRefreshToken(IdRofusClient client, dRofusServer server, string refreshToken, CancellationToken cancellationToken)
     {
-        var discoveryDocument = await GetDiscoveryDocument(client.HttpClient, server);
+        var discoveryDocument = await GetDiscoveryDocument(client.HttpClient, server).ConfigureAwait(false);
         var modernClient = client.HttpClient;
 
         var options = new OidcClientOptions
@@ -145,7 +145,7 @@ public class ModernPromptHandler(ModernLoginOptions modernLoginOptions, ILogger?
             LoadProfile = false
         };
         var oidcClient = new OidcClient(options);
-        var result = await oidcClient.RefreshTokenAsync(refreshToken, scope: modernLoginOptions.Scope, cancellationToken: cancellationToken);
+        var result = await oidcClient.RefreshTokenAsync(refreshToken, scope: modernLoginOptions.Scope, cancellationToken: cancellationToken).ConfigureAwait(false);
         
         if (result.IsError)
             throw new dRofusClientModernLoginException(result.Error)
@@ -156,7 +156,7 @@ public class ModernPromptHandler(ModernLoginOptions modernLoginOptions, ILogger?
 
     private async Task<DiscoveryDocumentResponse> GetDiscoveryDocument(HttpClient client, dRofusServer server)
     {
-        var discoveryDocument = await client.GetDiscoveryDocumentAsync(server.Authority);
+        var discoveryDocument = await client.GetDiscoveryDocumentAsync(server.Authority).ConfigureAwait(false);
         
         if (discoveryDocument.IsError)
             throw new dRofusClientLoginException(discoveryDocument.Error ?? "Failed to retrieve discovery document.");

--- a/src/dRofusClient/Occurrences/dRofusClientOccurenceExtensions.cs
+++ b/src/dRofusClient/Occurrences/dRofusClientOccurenceExtensions.cs
@@ -66,13 +66,13 @@ public static class dRofusClientOccurenceExtensions
         Occurence? occurenceResult = null;
 
         if (patchOptions.Body is not null && patchOptions.Body.Equals("{}") == false)
-            occurenceResult = await client.PatchAsync<Occurence>(dRofusType.Occurrences.CombineToRequest(occurence.Id), patchOptions, cancellationToken);
+            occurenceResult = await client.PatchAsync<Occurence>(dRofusType.Occurrences.CombineToRequest(occurence.Id), patchOptions, cancellationToken).ConfigureAwait(false);
 
         occurenceResult ??= occurence with { Id = occurence.Id, AdditionalProperties = occurence.AdditionalProperties };
 
         if (patchOptions.StatusFields is not null)
         {
-            var statusResults = await client.UpdateStatusesAsync(occurence.Id, patchOptions.StatusFields, cancellationToken);
+            var statusResults = await client.UpdateStatusesAsync(occurence.Id, patchOptions.StatusFields, cancellationToken).ConfigureAwait(false);
             UpdateStatusesOnOccurence(occurenceResult, statusResults);
         }
 
@@ -127,7 +127,7 @@ public static class dRofusClientOccurenceExtensions
             // Use the new extension method for KeyValuePair<string, object>
             var query = prop.ToStatusPatchOption();
 
-            var result = await client.UpdateOccurrenceStatusAsync(id.Value, query, cancellationToken);
+            var result = await client.UpdateOccurrenceStatusAsync(id.Value, query, cancellationToken).ConfigureAwait(false);
             results.Add(result);
         }
 
@@ -145,7 +145,7 @@ public static class dRofusClientOccurenceExtensions
     public static async Task<StatusPatchResult> UpdateOccurrenceStatusAsync(this IdRofusClient client, int id, StatusPatchRequest query, CancellationToken cancellationToken = default)
     {
         var request = dRofusType.Occurrences.CombineToRequest(id, "statuses", query.StatusTypeId.ToString());
-        var result = await client.PatchAsync<StatusPatchBody>(request, query, cancellationToken);
+        var result = await client.PatchAsync<StatusPatchBody>(request, query, cancellationToken).ConfigureAwait(false);
 
         return new StatusPatchResult
         {

--- a/src/dRofusClient/Projects/dRofusClientProjectExtensions.cs
+++ b/src/dRofusClient/Projects/dRofusClientProjectExtensions.cs
@@ -5,6 +5,6 @@ public static class dRofusClientProjectExtensions
 {
     public static async Task<Project> GetProjectAsync(this IdRofusClient client, ItemQuery? options = null, CancellationToken cancellationToken = default)
     {
-        return await client.SendAsync<Project>(HttpMethod.Get, dRofusType.Projects, options, cancellationToken);
+        return await client.SendAsync<Project>(HttpMethod.Get, dRofusType.Projects, options, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/dRofusClient/Rooms/dRofusClientRoomExtensions.cs
+++ b/src/dRofusClient/Rooms/dRofusClientRoomExtensions.cs
@@ -22,7 +22,7 @@ public static class dRofusClientRoomExtensions
         var patchOptions = room.ToPatchRequest();
         Room? result = null;
         if (patchOptions.Body is not null && patchOptions.Body != "{}")
-            result = await client.PatchAsync<Room>(dRofusType.Rooms.CombineToRequest(room.Id), patchOptions, cancellationToken);
+            result = await client.PatchAsync<Room>(dRofusType.Rooms.CombineToRequest(room.Id), patchOptions, cancellationToken).ConfigureAwait(false);
         result ??= room with { Id = room.Id };
         return result;
     }
@@ -97,7 +97,7 @@ public static class dRofusClientRoomExtensions
     {
         var (db, pr) = client.GetDatabaseAndProjectId();
         var url = $"/api/{db}/{pr}/" + dRofusType.Rooms.CombineToRequest("images", roomImageId.ToString());
-        return await client.HttpClient.GetByteArrayAsync(url);
+        return await client.HttpClient.GetByteArrayAsync(url).ConfigureAwait(false);
     }
 
     public static Task<Files.Image> GetRoomImageMetaAsync(this IdRofusClient client, int roomImageId, ItemQuery? query = default, CancellationToken cancellationToken = default)

--- a/src/dRofusClient/SystemBrowser.cs
+++ b/src/dRofusClient/SystemBrowser.cs
@@ -27,7 +27,7 @@ namespace dRofusClient
                 try
                 {
                     var contextTask = listener.GetContextAsync();
-                    if (await Task.WhenAny(contextTask, Task.Delay(300000, cancellationToken)) != contextTask)
+                    if (await Task.WhenAny(contextTask, Task.Delay(300000, cancellationToken)).ConfigureAwait(false) != contextTask)
                     {
                         return new BrowserResult
                         {
@@ -40,7 +40,7 @@ namespace dRofusClient
                     string responseString = "<html><head><script>setTimeout(function(){ window.close(); }, 1000);</script></head><body>You may now return to the app. This window will close automatically.</body></html>";
                     var buffer = Encoding.UTF8.GetBytes(responseString);
                     context.Response.ContentLength64 = buffer.Length;
-                    await context.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length, cancellationToken);
+                    await context.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
                     context.Response.OutputStream.Close();
 
                     string rawUrl = context.Request.RawUrl ?? "";

--- a/src/dRofusClient/Systems/dRofusClientSystemExtensions.cs
+++ b/src/dRofusClient/Systems/dRofusClientSystemExtensions.cs
@@ -48,7 +48,7 @@ public static class dRofusClientSystemExtensions
         var patchOptions = system.ToPatchRequest();
         SystemInstance? result = null;
         if (patchOptions.Body is not null && patchOptions.Body != "{}")
-            result = await client.PatchAsync<SystemInstance>(dRofusType.Systems.CombineToRequest(system.Id), patchOptions, cancellationToken);
+            result = await client.PatchAsync<SystemInstance>(dRofusType.Systems.CombineToRequest(system.Id), patchOptions, cancellationToken).ConfigureAwait(false);
         result ??= system with { Id = system.Id };
         return result;
     }


### PR DESCRIPTION
## Summary
- append `ConfigureAwait(false)` to awaited operations throughout the library and Windows helpers to prevent context capture

## Testing
- `dotnet test src/dRofusClient.Tests -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68961a2900a483268dbdb9e212033e1a