### PR TITLE
Add occurrence system membership support

### DIFF
--- a/src/dRofusClient.Revit/Occurrences/dRofusClientRevitOccurenceExtensions.cs
+++ b/src/dRofusClient.Revit/Occurrences/dRofusClientRevitOccurenceExtensions.cs
@@ -2,6 +2,7 @@ using dRofusClient.Options;
 using dRofusClient.Revit.Utils;
 using dRofusClient.Files;
 using dRofusClient.ApiLogs;
+using dRofusClient.Systems;
 
 namespace dRofusClient.Occurrences
 {
@@ -134,6 +135,14 @@ namespace dRofusClient.Occurrences
         public static List<Image> GetOccurrenceImages(this IdRofusClient client, int id, ListQuery query, CancellationToken cancellationToken = default)
         {
             return AsyncUtil.RunSync(() => client.GetOccurrenceImagesAsync(id, query, cancellationToken));
+        }
+
+        /// <summary>
+        /// Retrieves the systems that the occurrence is a member of.
+        /// </summary>
+        public static List<SystemInstance> GetOccurrenceSystems(this IdRofusClient client, int id, IsMemberOfSystemsQuery query, CancellationToken cancellationToken = default)
+        {
+            return AsyncUtil.RunSync(() => client.GetOccurrenceSystemsAsync(id, query, cancellationToken));
         }
     }
 }

--- a/src/dRofusClient.Tests/Occurrences/dRofusClientOccurrenceSystemTests.cs
+++ b/src/dRofusClient.Tests/Occurrences/dRofusClientOccurrenceSystemTests.cs
@@ -16,4 +16,21 @@ public class dRofusClientOccurrenceSystemTests
         await fake.GetOccurrenceSystemsAsync(12, query);
         Assert.Equal("occurrences/12/is-member-of-systems", fake.LastRequest);
     }
+
+    [Fact]
+    public async Task GetOccurrenceSystemsAsync_PassesIncludeSubsToRequest()
+    {
+        var fake = new FakeRofusClient();
+        var query = new IsMemberOfSystemsQuery
+        {
+            IncludeSubs = true
+        };
+
+        fake.ListAsyncResult = new List<dRofusSystem.SystemInstance>();
+
+        await fake.GetOccurrenceSystemsAsync(34, query);
+
+        Assert.Same(query, fake.LastOptions);
+        Assert.Equal("includeSubs=true", fake.LastOptions!.GetParameters());
+    }
 }

--- a/src/dRofusClient.Tests/dRofusRequestTests.cs
+++ b/src/dRofusClient.Tests/dRofusRequestTests.cs
@@ -1,4 +1,5 @@
 using dRofusClient.Occurrences;
+using dRofusClient.Options;
 
 namespace dRofusClient.Tests;
 
@@ -276,5 +277,27 @@ public class dRofusRequestTests
         var parameters = Query.List().Filter(
             Filter.IsNotEmpty("number")).GetParameters();
         Assert.Equal("$filter=number ne null", parameters);
+    }
+
+    [Fact]
+    public void IsMemberOfSystemsQuery_Includes_IncludeSubsFlag()
+    {
+        var parameters = new IsMemberOfSystemsQuery
+        {
+            IncludeSubs = true
+        }.GetParameters();
+
+        Assert.Equal("includeSubs=true", parameters);
+    }
+
+    [Fact]
+    public void IsMemberOfSystemsQuery_Handles_FalseIncludeSubsFlag()
+    {
+        var parameters = new IsMemberOfSystemsQuery
+        {
+            IncludeSubs = false
+        }.GetParameters();
+
+        Assert.Equal("includeSubs=false", parameters);
     }
 }


### PR DESCRIPTION
## Summary
- add synchronous Revit helper for occurrence system membership endpoint
- validate the is-member-of-systems query includes the includeSubs flag
- ensure the occurrence systems endpoint forwards query parameters correctly

## Testing
- dotnet test src/dRofusClient.Tests/dRofusClient.Tests.csproj

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942a31fdc308326856fdcc8b968e6a3)